### PR TITLE
add enrollment creation timestamp to pipleline data

### DIFF
--- a/src/ol_data_pipelines/mitx_bigquery/solids.py
+++ b/src/ol_data_pipelines/mitx_bigquery/solids.py
@@ -80,6 +80,7 @@ def download_user_data(
         "profile_name",
         "profile_meta",
         "enrollment_course_id",
+        "enrollment_created",
     ]
 
     file_system, output_folder = fs.FileSystem.from_uri(


### PR DESCRIPTION
I did not include the enrollment creation timestamp as a field we want to pull in the original PR. This is useful information in general and also will make incremental updates to the open enrollment data possible.