### PR TITLE
Ab/pull open data

### DIFF
--- a/src/ol_data_pipelines/lib/arrow_helper.py
+++ b/src/ol_data_pipelines/lib/arrow_helper.py
@@ -1,0 +1,47 @@
+"""Helper class for parquet data output."""
+from pyarrow import concat_tables, fs, parquet
+
+
+def write_parquet_file(file_system, output_folder, arrow_table, file_name):
+    """Output an arrow table as a parquet file.
+
+    :file_system: pyarrow interchangable filesystem. May be local, S3, etc.
+    :type file_system: pyarrow FileSystem type
+
+    :output_folder: Folder for outputs
+    :type output_folder: String
+
+    :arrow_table: Arrow table to be written as parquet file
+    :type arrow_table: pyarrow.Table
+
+    :file_name: Name for parquet file
+    :type file_name: String
+    """
+    file_path = "{output_folder}/{file_name}.parquet".format(
+        output_folder=output_folder, file_name=file_name
+    )
+
+    with file_system.open_output_stream(file_path) as parquet_file:
+        with parquet.ParquetWriter(parquet_file, arrow_table.schema) as writer:
+            writer.write_table(arrow_table)
+
+
+def stream_to_parquet_file(
+    arrow_table_generator, file_base, file_system, output_folder
+):
+    """Write to numbered parquet files from a generator.
+
+    :arrow_table_generator: generator that yeilds arrow tables
+    :type arrow_table_generator: Generator
+
+    :file_base: base name for parquet files
+    :type file_base: String
+
+    :file_system: pyarrow interchangable filesystem. May be local, S3, etc.
+    :type file_system: pyarrow FileSystem type
+
+    :output_folder: Folder for outputs
+    :type output_folder: String
+    """
+    arrow_table = concat_tables(arrow_table_generator)
+    write_parquet_file(file_system, output_folder, arrow_table, file_base)

--- a/src/ol_data_pipelines/mitx_bigquery/repositories.py
+++ b/src/ol_data_pipelines/mitx_bigquery/repositories.py
@@ -1,3 +1,4 @@
+"""Repository for pipeline pulling MITx bigquery data to S3"""
 from dagster import repository
 
 from ol_data_pipelines.mitx_bigquery.solids import mitx_bigquery_pipeline
@@ -5,4 +6,5 @@ from ol_data_pipelines.mitx_bigquery.solids import mitx_bigquery_pipeline
 
 @repository
 def mitx_bigquery_repository():
+    """repository for mitx bigquery pipeline"""
     return [mitx_bigquery_pipeline]

--- a/src/ol_data_pipelines/open_discussions/repositories.py
+++ b/src/ol_data_pipelines/open_discussions/repositories.py
@@ -1,0 +1,10 @@
+"""Reposiotries for open-discussions pipelines"""
+from dagster import repository
+
+from ol_data_pipelines.open_discussions.solids import pull_open_data_pipeline
+
+
+@repository
+def open_data_repository():
+    """repository for pulling open and run data to s3"""
+    return [pull_open_data_pipeline]

--- a/src/ol_data_pipelines/open_discussions/solids.py
+++ b/src/ol_data_pipelines/open_discussions/solids.py
@@ -1,0 +1,184 @@
+"""Pipeline for uploading open-discussions user and run data to s3."""
+from dagster import (  # noqa: WPS235
+    Field,
+    Int,
+    ModeDefinition,
+    Noneable,
+    Output,
+    OutputDefinition,
+    PresetDefinition,
+    SolidExecutionContext,
+    String,
+    pipeline,
+    solid,
+)
+from pyarrow import fs
+from pypika import PostgreSQLQuery as Query
+from pypika import Table, Tables
+
+from ol_data_pipelines.lib.arrow_helper import stream_to_parquet_file
+from ol_data_pipelines.lib.yaml_config_helper import load_yaml_config
+from ol_data_pipelines.resources.postgres_db import postgres_db_resource
+
+
+@solid(
+    description=("Query postgres and data as parquet files "),
+    required_resource_keys={"postgres_db"},
+    config_schema={
+        "chunksize": Field(
+            Int,
+            is_required=False,
+            default_value=5000,
+            description="Number of rows per parquet file",
+        ),
+        "outputs_dir": Field(
+            String, is_required=True, description="Path for output files"
+        ),
+        "file_base": Field(String, is_required=True, description="base_name_for_file"),
+        "minimum_timestamp": Field(
+            Noneable(str),
+            is_required=False,
+            default_value=None,
+            description="Minimum minimum_timestamp for user date_joined. Format yyyy-mm-dd",
+        ),
+    },
+    output_defs=[
+        OutputDefinition(
+            name="query_folder",
+            dagster_type=String,
+            description="Path to user data rendered as parquet config_files",
+        )
+    ],
+)
+def fetch_open_user_data(context: SolidExecutionContext):
+    """
+    Fetch open user data parquet files.
+
+    :param context: Dagster execution context for configuration data
+    :type context: SolidExecutionContext
+
+    :yield: A path definition that points to the the folder containing the data
+    """
+    users = Table("auth_user")
+    query = Query.from_(users).select("id", "email", "date_joined")
+
+    if context.solid_config["minimum_timestamp"]:
+        query = query.where(
+            users.date_joined > context.solid_config["minimum_timestamp"]
+        )
+
+    file_system, output_folder = fs.FileSystem.from_uri(
+        context.solid_config["outputs_dir"]
+    )
+
+    stream_to_parquet_file(
+        context.resources.postgres_db.run_chunked_query(
+            query, context.solid_config["chunksize"]
+        ),
+        context.solid_config["file_base"],
+        file_system,
+        output_folder,
+    )
+
+    yield Output(output_folder, "query_folder")
+
+
+@solid(
+    description=("Retrieve run information from open and write it as parquet files "),
+    required_resource_keys={"postgres_db"},
+    config_schema={
+        "chunksize": Field(
+            Int,
+            is_required=False,
+            default_value=5000,
+            description="Number of rows per parquet file",
+        ),
+        "outputs_dir": Field(
+            String, is_required=True, description="Path for output files"
+        ),
+        "file_base": Field(String, is_required=True, description="base_name_for_file"),
+        "minimum_timestamp": Field(
+            Noneable(str),
+            is_required=False,
+            default_value=None,
+            description="Minimum minimum_timestamp for run created_on. Format yyyy-mm-dd",
+        ),
+    },
+    output_defs=[
+        OutputDefinition(
+            name="query_folder",
+            dagster_type=String,
+            description="Path to user data rendered as parquet config_files",
+        )
+    ],
+)
+def fetch_open_run_data(context: SolidExecutionContext):  # noqa: WPS210
+    """
+    Fetch open run data as parquet files.
+
+    :param context: Dagster execution context for configuration data
+    :type context: SolidExecutionContext
+
+    :yield: A path definition that points to the the folder containing the data
+    """
+    run_offerors, runs, offerors = Tables(
+        "course_catalog_learningresourcerun_offered_by",
+        "course_catalog_learningresourcerun",
+        "course_catalog_learningresourceofferor",
+    )
+    query = (
+        Query.from_(run_offerors)  # noqa: WPS221
+        .join(runs)
+        .on(runs.id == run_offerors.learningresourcerun_id)
+        .join(offerors)
+        .on(offerors.id == run_offerors.learningresourceofferor_id)
+        .select(
+            runs.id, runs.run_id, runs.created_on, (offerors.name).as_("offeror_name")
+        )
+        .where(runs.published == True)  # noqa: E712
+    )
+
+    if context.solid_config["minimum_timestamp"]:
+        query = query.where(runs.created_on > context.solid_config["minimum_timestamp"])
+
+    file_system, output_folder = fs.FileSystem.from_uri(
+        context.solid_config["outputs_dir"]
+    )
+
+    stream_to_parquet_file(
+        context.resources.postgres_db.run_chunked_query(
+            query, context.solid_config["chunksize"]
+        ),
+        context.solid_config["file_base"],
+        file_system,
+        output_folder,
+    )
+
+    yield Output(output_folder, "query_folder")
+
+
+@pipeline(
+    description="Retrieve user information from open and write it as parquet files",
+    mode_defs=[
+        ModeDefinition(
+            name="production",
+            resource_defs={"postgres_db": postgres_db_resource},
+        )
+    ],
+    preset_defs=[
+        PresetDefinition(
+            name="production",
+            run_config=load_yaml_config("/etc/dagster/open-discussions.yaml"),
+            mode="production",
+        )
+    ],
+    tags={
+        "source": "open_discussions",
+        "destination": "s3",
+        "owner": "platform-engineering",
+    },
+)
+def pull_open_data_pipeline():
+    """Pipeline for pulling open user and run data to s3."""
+    fetch_open_run_data()
+    fetch_open_user_data()

--- a/src/ol_data_pipelines/resources/bigquery_db.py
+++ b/src/ol_data_pipelines/resources/bigquery_db.py
@@ -1,6 +1,8 @@
-from dagster import Field, InitResourceContext, String, resource
+"""resource for connection to a bigquery database"""
+
 from google.cloud import bigquery
 from google.oauth2 import service_account
+from dagster import Field, InitResourceContext, String, resource
 
 
 @resource(

--- a/src/ol_data_pipelines/resources/postgres_db.py
+++ b/src/ol_data_pipelines/resources/postgres_db.py
@@ -1,0 +1,116 @@
+"""Resource for connection to a postgres db."""
+from typing import Text
+
+import pandas
+import psycopg2
+import pyarrow
+from dagster import Field, InitResourceContext, Int, String, resource
+from pypika import Query
+
+DEFAULT_POSTGRES_PORT = 5432
+
+
+class PostgresClient:
+    def __init__(  # noqa: WPS211
+        self,
+        hostname: Text,
+        username: Text,
+        password: Text,
+        db_name: Text,
+        port: Int = DEFAULT_POSTGRES_PORT,
+    ):
+        """Instantiate a connection to a Postgres database.
+
+        :param hostname: DNS or IP address of Postgres database
+        :type hostname: Text
+
+        :param username: Username for Postgres database
+        :type username: Text
+
+        :param password: Password for specified username
+        :type password: Text
+
+        :param db_name: Database name to run queries in
+        :type db_name: Text
+
+        :param port: Port number for Postgres database
+        :type port: Int
+        """
+        self.connection = psycopg2.connect(
+            dbname=db_name,
+            user=username,
+            password=password,
+            host=hostname,
+            port=port,
+        )
+
+    def run_chunked_query(self, query: Query, chunksize: Int) -> pyarrow.Table:
+        """Execute the passed query against the Postgres connection and yeild the row data as Arrow Table.
+
+        :param query: PyPika query object that specifies the desired query
+        :type query: Query
+
+        :param chunksize: PyPika query object that specifies the desired query
+        :type chunksize: Int
+
+        :yields: chunked Query results as arrow table
+
+        :rtype: Table
+        """
+        for chunk in pandas.read_sql_query(  # noqa: WPS352
+            str(query),
+            self.connection,
+            chunksize=chunksize,
+        ):
+            arrow_table = pyarrow.Table.from_pandas(chunk)
+            yield arrow_table
+
+
+@resource(
+    config_schema={
+        "postgres_hostname": Field(
+            String, is_required=True, description="Host string for Postgres server"
+        ),
+        "postgres_port": Field(
+            Int,
+            is_required=False,
+            default_value=DEFAULT_POSTGRES_PORT,
+            description="TCP Port number for Postgres server",
+        ),
+        "postgres_username": Field(
+            String,
+            is_required=True,
+            description="Username for authenticating to Postgres server",
+        ),
+        "postgres_password": Field(
+            String,
+            is_required=True,
+            description="Password for authenticating to Postgres server",
+        ),
+        "postgres_db_name": Field(
+            String,
+            is_required=True,
+            description="Database name to connect to for executing queries",
+        ),
+    }
+)
+def postgres_db_resource(resource_context: InitResourceContext):
+    """
+     Create a connection to a postgres database.
+
+    :param resource_context: Dagster execution context for configuration data
+    :type resource_context: InitResourceContext
+
+    :yields: A postgres client instance for use during pipeline execution.
+    """
+    client = PostgresClient(
+        hostname=resource_context.resource_config["postgres_hostname"],
+        username=resource_context.resource_config["postgres_username"],
+        password=resource_context.resource_config["postgres_password"],
+        port=resource_context.resource_config["postgres_port"],
+        db_name=resource_context.resource_config["postgres_db_name"],
+    )
+
+    yield client
+
+    client.connection.close()

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -8,3 +8,6 @@ load_from:
   - python_package:
       package_name: ol_data_pipelines.mitx_bigquery.repositories
       attribute: mitx_bigquery_repository
+  - python_package:
+      package_name: ol_data_pipelines.open_discussions.repositories
+      attribute: open_data_repository


### PR DESCRIPTION
This pr creates a pipeline for downloading user and run data from the open database to file/s3 as parquet files.
This is part of https://github.com/mitodl/ol-data-pipelines/issues/18

Sample config (with database keys removed):
```
resources:
  postgres_db:
    config:
      dbname: opendiscussions
      host: 
      password: 
      port: 5432
      user:
solids:
  download_run_data:
    config:
      outputs_dir: /etc/dagster/open_run_data
      file_base: run_data
  download_user_data:
    config:
      file_base: run_data
      outputs_dir: /etc/dagster/open_user_data
```