### PR TITLE
ab/fix-timestamp-format

### DIFF
--- a/src/ol_data_pipelines/lib/arrow_helper.py
+++ b/src/ol_data_pipelines/lib/arrow_helper.py
@@ -1,5 +1,5 @@
 """Helper class for parquet data output."""
-from pyarrow import concat_tables, fs, parquet
+from pyarrow import concat_tables, parquet
 
 
 def write_parquet_file(file_system, output_folder, arrow_table, file_name):
@@ -22,7 +22,9 @@ def write_parquet_file(file_system, output_folder, arrow_table, file_name):
     )
 
     with file_system.open_output_stream(file_path) as parquet_file:
-        with parquet.ParquetWriter(parquet_file, arrow_table.schema) as writer:
+        with parquet.ParquetWriter(
+            parquet_file, arrow_table.schema, use_deprecated_int96_timestamps=True
+        ) as writer:
             writer.write_table(arrow_table)
 
 


### PR DESCRIPTION
closes https://github.com/mitodl/ol-data-pipelines/issues/21

Timestamps imported from parquet to athena are corrupted. By default parquet 2.0 saves timestams in int64 format but amazon glue crawlers expect int96 format.

Setting use_deprecated_int96_timestamps=True on the writer fixes the issue